### PR TITLE
devregs: add support for imx8mn soc

### DIFF
--- a/src/devregs.cpp
+++ b/src/devregs.cpp
@@ -717,6 +717,10 @@ static int getcpu(unsigned &cpu, const char *path) {
 				cpu = 0x82;
 				break;
 			}
+			if (strstr(inBuf, "i.MX8MN")) {
+				cpu = 0x82;
+				break;
+			}
 			if (!get_rev(inBuf, "Revision", &cpu))
 				if (cpu != 0x10)
 					break;


### PR DESCRIPTION
i.MX8M Nano SoC is very close to i.MX8M Mini, therefore we would allow
them to use the same register description file.

Signed-off-by: Andrey Zhizhikin <andrey.zhizhikin@leica-geosystems.com>